### PR TITLE
Feat/auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### .env ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,6 @@ dependencies {
     // Hibernate Validator: Java Bean Validation (유효성 검사) 구현체
     implementation 'org.hibernate.validator:hibernate-validator'
 
-    // Thymeleaf: HTML 템플릿 엔진 (컨트롤러와 뷰를 연결)
-    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-
     // Spring Boot JPA: 데이터베이스 액세스를 위한 JPA 지원 (Hibernate 포함)
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
@@ -59,6 +56,17 @@ dependencies {
 
     // Jakarta Persistence API 어노테이션 처리기 (QueryDSL과 함께 사용)
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+    // Spring Security: 애플리케이션 보안을 위한 라이브러리
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT: JSON Web Token 생성 및 검증
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 파싱 지원
+
+    // Spring Boot DevTools: 개발 중 핫 리로딩 지원
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
     // Spring Boot DevTools: 개발 중 핫 리로딩 지원
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // Spring Dotenv: .env 파일 지원 라이브러리 추가
+    implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: sparta-delivery-app
+    ports:
+      - "3306:3306"
+
+
+

--- a/src/main/java/com/example/auth/controller/AuthController.java
+++ b/src/main/java/com/example/auth/controller/AuthController.java
@@ -1,0 +1,49 @@
+package com.example.auth.controller;
+
+import com.example.auth.dto.AuthRequest;
+import com.example.user.entity.User;
+import com.example.user.repository.UserRepository;
+import com.example.utils.JwtUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AuthController(JwtUtil jwtUtil, UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody AuthRequest authRequest) {
+        // 사용자 정보 로드
+        User user = userRepository.findByEmail(authRequest.getEmail())
+                .orElseThrow(() -> new RuntimeException("Invalid email or password"));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(authRequest.getPassword(), user.getPassword())) {
+            throw new RuntimeException("Invalid email or password");
+        }
+
+        // JWT 토큰 생성
+        String token = jwtUtil.generateToken(user.getId(), user.getEmail(), user.getRole().getAuthority());
+
+        // Authorization 헤더에 토큰 추가
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+
+        // 헤더만 포함하고 본문은 비움
+        return ResponseEntity.ok()
+                .headers(headers)
+                .build();
+    }
+}

--- a/src/main/java/com/example/auth/dto/AuthRequest.java
+++ b/src/main/java/com/example/auth/dto/AuthRequest.java
@@ -1,0 +1,16 @@
+package com.example.auth.dto;
+
+public class AuthRequest {
+    private String email;
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/src/main/java/com/example/auth/dto/AuthResponse.java
+++ b/src/main/java/com/example/auth/dto/AuthResponse.java
@@ -1,0 +1,18 @@
+package com.example.auth.dto;
+
+public class AuthResponse {
+    private String token;
+
+    public AuthResponse(String token) {
+        this.token = token;
+    }
+
+    // Getters and setters
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/example/config/SecurityConfig.java
+++ b/src/main/java/com/example/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.example.config;
+
+
+import com.example.filter.JwtFilter;
+import com.example.user.entity.Role;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    public SecurityConfig(JwtFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**", "/user/register", "/error").permitAll()
+                        .requestMatchers("/customer/**").hasRole(Role.CUSTOMER.name())
+                        .requestMatchers("/owner/**").hasRole(Role.OWNER.name())
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/example/filter/JwtFilter.java
+++ b/src/main/java/com/example/filter/JwtFilter.java
@@ -1,0 +1,65 @@
+package com.example.filter;
+
+import com.example.security.UserDetailsImpl;
+import com.example.utils.JwtUtil;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        String email = null;
+        String jwt = null;
+
+        try {
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                jwt = authorizationHeader.substring(7);
+                email = jwtUtil.extractEmail(jwt);
+            }
+
+            if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                if (userDetails instanceof UserDetailsImpl userDetailsImpl) {
+                    if (jwtUtil.isTokenValid(jwt, userDetailsImpl.getEmail())) {
+                        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                                userDetails, null, userDetails.getAuthorities()
+                        );
+                        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // 인증 실패 시 로그를 남기고 다음 필터로 넘깁니다.
+            logger.warn("JWT 인증 실패: " + e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/example/security/UserDetailsImpl.java
+++ b/src/main/java/com/example/security/UserDetailsImpl.java
@@ -1,0 +1,60 @@
+package com.example.security;
+
+import com.example.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().getAuthority()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    public int getId() {
+        return user.getId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/security/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.security;
+
+import com.example.user.entity.User;
+import com.example.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/example/user/controller/UserController.java
+++ b/src/main/java/com/example/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package com.example.user.controller;
+
+import com.example.user.dto.UserRegisterRequest;
+import com.example.user.dto.UserRegisterResponse;
+import com.example.user.entity.User;
+import com.example.user.service.UserService;
+import com.example.utils.AuthUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<UserRegisterResponse> registerUser(@RequestBody UserRegisterRequest request) {
+        // 회원가입 처리
+        User user = userService.registerUser(request.getEmail(), request.getPassword(), request.getRole());
+
+        // 응답 반환
+        UserRegisterResponse response = new UserRegisterResponse(
+                user.getEmail(),
+                "User registered successfully"
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<Integer> getAuthenticatedUserId() {
+        // 인증된 사용자의 ID를 가져옵니다.
+        Integer userId = AuthUtil.getId();
+        if (userId == null) {
+            return ResponseEntity.status(401).build(); // 인증되지 않은 경우 401 반환
+        }
+
+        return ResponseEntity.ok(userId); // 사용자 ID 반환
+    }
+
+}

--- a/src/main/java/com/example/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/example/user/dto/UserRegisterRequest.java
@@ -1,0 +1,34 @@
+package com.example.user.dto;
+
+import com.example.user.entity.Role;
+
+public class UserRegisterRequest {
+    private String email;
+    private String password;
+    private Role role;
+
+    // Getters and setters
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/user/dto/UserRegisterResponse.java
+++ b/src/main/java/com/example/user/dto/UserRegisterResponse.java
@@ -1,0 +1,21 @@
+package com.example.user.dto;
+
+public class UserRegisterResponse {
+    private String email;
+    private String message;
+
+    public UserRegisterResponse(String email, String message) {
+        this.email = email;
+        this.message = message;
+    }
+
+    // Getters
+    public String getEmail() {
+        return email;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/example/user/entity/Role.java
+++ b/src/main/java/com/example/user/entity/Role.java
@@ -1,0 +1,4 @@
+package com.example.user.entity;
+
+public enum Role {
+}

--- a/src/main/java/com/example/user/entity/Role.java
+++ b/src/main/java/com/example/user/entity/Role.java
@@ -1,4 +1,9 @@
 package com.example.user.entity;
 
 public enum Role {
+    CUSTOMER, OWNER;
+
+    public String getAuthority() {
+        return "ROLE_" + this.name();
+    }
 }

--- a/src/main/java/com/example/user/entity/User.java
+++ b/src/main/java/com/example/user/entity/User.java
@@ -19,17 +19,17 @@ public class User {
     private int id;
 
     @Setter
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false)
     private String name;
 
     @Setter
-    @Column(nullable = false, length = 50, unique = true)
-    @Email(message = "이메일 형식이 맞지 않습니다.") // 이메일 형식 검증
-    @NotNull(message = "이메일을 입력하여 주세요.") // null 방지
+    @Column(nullable = false, unique = true)
+    @Email
+    @NotNull
     private String email;
 
     @Setter
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false)
     private String password;
 
     @Setter
@@ -37,6 +37,7 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Setter
     private Role role;
 
     @Column(updatable = false)

--- a/src/main/java/com/example/user/entity/User.java
+++ b/src/main/java/com/example/user/entity/User.java
@@ -35,6 +35,10 @@ public class User {
     @Setter
     private Boolean isOwner;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Column(updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;

--- a/src/main/java/com/example/user/repository/UserRepository.java
+++ b/src/main/java/com/example/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.user.repository;
+
+
+import com.example.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/user/service/UserService.java
+++ b/src/main/java/com/example/user/service/UserService.java
@@ -1,0 +1,34 @@
+package com.example.user.service;
+
+import com.example.user.entity.Role;
+import com.example.user.entity.User;
+import com.example.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User registerUser(String email, String rawPassword, Role role) {
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(email)) {
+            throw new RuntimeException("Email already in use: " + email);
+        }
+
+        // 사용자 생성 및 저장
+        User user = new User();
+        user.setName("name");
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        user.setRole(role);
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/utils/AuthUtil.java
+++ b/src/main/java/com/example/utils/AuthUtil.java
@@ -1,0 +1,27 @@
+package com.example.utils;
+
+import com.example.security.UserDetailsImpl;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuthUtil {
+
+    private AuthUtil() {
+        // 유틸리티 클래스의 인스턴스화를 방지
+    }
+
+    /**
+     * 현재 인증된 사용자의 ID를 가져옵니다.
+     *
+     * @return 사용자 ID (없으면 null)
+     */
+    public static Integer getId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetailsImpl userDetails) {
+            return userDetails.getId(); // 사용자 ID 반환
+        }
+
+        return null; // 인증되지 않은 경우
+    }
+}

--- a/src/main/java/com/example/utils/JwtUtil.java
+++ b/src/main/java/com/example/utils/JwtUtil.java
@@ -1,0 +1,69 @@
+package com.example.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Date;
+import java.util.function.Function;
+
+@Component
+public class JwtUtil {
+
+    private final Key SECRET_KEY;
+    private final long TOKEN_VALIDITY;
+
+    public JwtUtil(
+            @Value("${jwt.secret:default-secure-key-must-be-32-chars}") String secret, // 32자 기본값
+            @Value("${jwt.token-validity:3600000}") long tokenValidity // 1시간(3600000ms) 기본값
+    ) {
+        this.SECRET_KEY = new SecretKeySpec(secret.getBytes(), SignatureAlgorithm.HS256.getJcaName());
+        this.TOKEN_VALIDITY = tokenValidity;
+    }
+
+    public String generateToken(int id, String email, String role) {
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("id", id)
+                .claim("role", role)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALIDITY))
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public String extractRole(String token) {
+        return extractAllClaims(token).get("role", String.class);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(SECRET_KEY)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean isTokenValid(String token, String email) {
+        System.out.println("check if it is valid");
+        System.out.println(extractEmail(token).equals(email) && !isTokenExpired(token));
+        return extractEmail(token).equals(email) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractAllClaims(token).getExpiration().before(new Date());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 spring.application.name=DeliveryApp
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.JdbcClientAutoConfiguration
 spring.datasource.url=jdbc:mysql://localhost:3306/sparta-delivery-app
-spring.datasource.username=
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create
+spring.datasource.username=${DB_USERNAME:}
+spring.datasource.password=${DB_PASSWORD:}
+spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO:create}
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.type=true
 spring.jpa.open-in-view=false
-logging.level.org.hibernate.SQL=DEBUG
+logging.level.root=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE


### PR DESCRIPTION
일단 기능만 구현 했습니다.

```
 Integer userId = AuthUtil.getId();
```

이런 식으로 인증된 user의 id를 가져올 수 있습니다.

---
아래의 결로로 시작하는 경로는 role이 CUSTOMER인 user만 접근 가능하고
```
"/customer/**"
```

아래의 결로로 시작하는 경로는 role이 OWNER인 user만 접근 가능하고
```
/owner/**
```

아래의 경로는 인증되지 않아도 접근이 가능합니다.
```
"/auth/**", "/user/register"
```

위에서 언급되지 않은 모든 경로는 역할에 상관없이 인증된 사용자만 접근가능합니다.


로그인 후 토큰은 header를 통해서 Bearer .... 형식으로 전달됩니다.
인증이 필요한 경로로 요청을 보낼 경우 마찬가지로 header의 authorization에 Bear .... 형식으로 jwt를 전달해주면 됩니다.